### PR TITLE
Remove deprecated warn flag in newer Ansible command module

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -43,8 +43,6 @@
 
 - name: Gather currently installed systemd_exporter version (if any)
   command: "{{ _systemd_exporter_binary_install_dir }}/systemd_exporter --version"
-  args:
-    warn: false
   changed_when: false
   register: __systemd_exporter_current_version_output
   check_mode: false


### PR DESCRIPTION
This change works on this role as well:

https://github.com/cloudalchemy/ansible-node-exporter/pull/274#issue-1458811271