### PR TITLE
Assert that systemd version is >= 235

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -24,7 +24,7 @@
 - name: Assert that systemd version is >= 235 when enabling ip accounting or measuring restart count
   assert:
     that:
-      - _systemd_exporter_systemd_version | int >= 232
+      - _systemd_exporter_systemd_version | int >= 235
   when: systemd_exporter_enable_ip_accounting or systemd_exporter_enable_restart_count
 
 - name: Set user and group to root to allow access to /proc/X/fd


### PR DESCRIPTION
The task name said it checks for
` >= 235`
but actually checked for 
`>= 232`
