### PR TITLE
update cli parameter to new release

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `systemd_exporter_enable_restart_count` | false | Enables service restart count metrics. This feature only works with systemd 235 and above |
 | `systemd_exporter_enable_ip_accounting` | false | Enables service ip accounting metrics. This feature only works with systemd 235 and above |
 | `systemd_exporter_enable_file_descriptor_size` | false | Enables file descriptor size metrics. This feature will cause exporter to run as root as it needs access to /proc/X/fd |
-| `systemd_exporter_unit_allowlist` | "" | Include some systemd units. Expects a regex. More in https://github.com/povilasv/systemd_exporter#configuration |
-| `systemd_exporter_unit_denylist` | "" | Exclude some systemd units. Expects a regex. More in https://github.com/povilasv/systemd_exporter#configuration |
+| `systemd_exporter_unit_includelist` | "" | Include some systemd units. Expects a regex. More in https://github.com/povilasv/systemd_exporter#configuration |
+| `systemd_exporter_unit_excludelist` | "" | Exclude some systemd units. Expects a regex. More in https://github.com/povilasv/systemd_exporter#configuration |
 
 ## Example
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,7 +21,7 @@
     - name: Download systemd_exporter binary to local folder
       become: false
       get_url:
-        url: "https://github.com/povilasv/systemd_exporter/releases/download/v{{ systemd_exporter_version }}/systemd_exporter-{{ systemd_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        url: "https://github.com/prometheus-community/systemd_exporter/releases/download/v{{ systemd_exporter_version }}/systemd_exporter-{{ systemd_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         dest: "/tmp/systemd_exporter-{{ systemd_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ systemd_exporter_checksum }}"
         mode: '0644'

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -56,7 +56,7 @@
 - block:
     - name: Get latest release
       uri:
-        url: "https://api.github.com/repos/povilasv/systemd_exporter/releases/latest"
+        url: "https://api.github.com/repos/prometheus-community/systemd_exporter/releases/latest"
         method: GET
         return_content: true
         status_code: 200
@@ -80,7 +80,7 @@
 - block:
     - name: Get checksum list from github
       set_fact:
-        _checksums: "{{ lookup('url', 'https://github.com/povilasv/systemd_exporter/releases/download/v' + systemd_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
+        _checksums: "{{ lookup('url', 'https://github.com/prometheus-community/systemd_exporter/releases/download/v' + systemd_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
       run_once: true
 
     - name: "Get checksum for {{ go_arch }} architecture"

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -24,7 +24,7 @@
 - name: Assert that systemd version is >= 235 when enabling ip accounting or measuring restart count
   assert:
     that:
-      - _systemd_exporter_systemd_version | int >= 232
+      - _systemd_exporter_systemd_version | int >= 235
   when: systemd_exporter_enable_ip_accounting or systemd_exporter_enable_restart_count
 
 - name: Set user and group to root to allow access to /proc/X/fd

--- a/templates/systemd_exporter.service.j2
+++ b/templates/systemd_exporter.service.j2
@@ -18,11 +18,11 @@ ExecStart={{ _systemd_exporter_binary_install_dir }}/systemd_exporter \
 {% if systemd_exporter_enable_ip_accounting %}
     --systemd.collector.enable-ip-accounting \
 {% endif %}
-{% if systemd_exporter_unit_whitelist != ""%}
-    --systemd.collector.unit-include={{ systemd_exporter_unit_whitelist }} \
+{% if systemd_exporter_unit_includelist != ""%}
+    --systemd.collector.unit-include="{{ systemd_exporter_unit_includelist }}" \
 {% endif %}
-{% if systemd_exporter_unit_blacklist != "" %}
-    --systemd.collector.unit-exclude={{ systemd_exporter_unit_blacklist }} \
+{% if systemd_exporter_unit_excludelist != "" %}
+    --systemd.collector.unit-exclude="{{ systemd_exporter_unit_excludelist }}" \
 {% endif %}
     --web.listen-address={{ systemd_exporter_web_listen_address }}
 

--- a/templates/systemd_exporter.service.j2
+++ b/templates/systemd_exporter.service.j2
@@ -10,19 +10,19 @@ User={{ _systemd_exporter_system_user }}
 Group={{ _systemd_exporter_system_group }}
 ExecStart={{ _systemd_exporter_binary_install_dir }}/systemd_exporter \
 {% if systemd_exporter_enable_restart_count %}
-    --collector.enable-restart-count \
+    --systemd.collector.enable-restart-count \
 {% endif %}
 {% if systemd_exporter_enable_file_descriptor_size %}
-    --collector.enable-file-descriptor-size \
+    --systemd.collector.enable-file-descriptor-size \
 {% endif %}
 {% if systemd_exporter_enable_ip_accounting %}
-    --collector.enable-ip-accounting \
+    --systemd.collector.enable-ip-accounting \
 {% endif %}
 {% if systemd_exporter_unit_whitelist != ""%}
-    --collector.unit-whitelist={{ systemd_exporter_unit_whitelist }} \
+    --systemd.collector.unit-include={{ systemd_exporter_unit_whitelist }} \
 {% endif %}
 {% if systemd_exporter_unit_blacklist != "" %}
-    --collector.unit-blacklist={{ systemd_exporter_unit_blacklist }} \
+    --systemd.collector.unit-exclude={{ systemd_exporter_unit_blacklist }} \
 {% endif %}
     --web.listen-address={{ systemd_exporter_web_listen_address }}
 


### PR DESCRIPTION
add "systemd." to most cli switches
whitelist > include
blacklist > exclude

```
./systemd_exporter  --version
systemd_exporter, version 0.5.0 (branch: HEAD, revision: 46a98612ae97d0da72d85cef3d52cede8f18c432)
  build user:       root@dbf333bc716d
  build date:       20220720-17:20:46
  go version:       go1.18.4
  platform:         linux/amd64

./systemd_exporter  -h
usage: systemd_exporter [<flags>]

Flags:
  -h, --help                    Show context-sensitive help (also try --help-long and --help-man).
      --systemd.collector.unit-include=".+"  
                                Regexp of systemd units to include. Units must both match include and not match exclude to be included.
      --systemd.collector.unit-exclude=".+\\.(device)"  
                                Regexp of systemd units to exclude. Units must both match include and not match exclude to be included.
      --systemd.collector.private  
                                Establish a private, direct connection to systemd without dbus.
      --systemd.collector.user  Connect to the user systemd instance.
      --path.procfs="/proc"     procfs mountpoint.
      --systemd.collector.enable-restart-count  
                                Enables service restart count metrics. This feature only works with systemd 235 and above.
      --systemd.collector.enable-file-descriptor-size  
                                Enables file descriptor size metrics. Systemd Exporter needs access to /proc/X/fd for this to work.
      --systemd.collector.enable-ip-accounting  
                                Enables service ip accounting metrics. This feature only works with systemd 235 and above.
      --web.listen-address=":9558"  
                                Address on which to expose metrics and web interface.
      --web.telemetry-path="/metrics"  
                                Path under which to expose metrics.
      --web.disable-exporter-metrics  
                                Exclude metrics about the exporter itself (promhttp_*, process_*, go_*).
      --web.max-requests=40     Maximum number of parallel scrape requests. Use 0 to disable.
      --web.config.file=""      [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.
      --log.level=info          Only log messages with the given severity or above. One of: [debug, info, warn, error]
      --log.format=logfmt       Output format of log messages. One of: [logfmt, json]
      --version                 Show application version.

```