### PR TITLE
general overhaul to upstream version 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `systemd_exporter_version` | 0.4.0 | SystemD exporter package version. Also accepts latest as parameter. |
+| `systemd_exporter_version` | 0.5.0 | SystemD exporter package version. Also accepts latest as parameter. |
 | `systemd_exporter_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `systemd_exporter` binary is stored on host on which ansible is ran. This overrides `systemd_exporter_version` parameter |
 | `systemd_exporter_web_listen_address` | "0.0.0.0:9558" | Address on which systemd exporter will listen |
 | `systemd_exporter_enable_restart_count` | false | Enables service restart count metrics. This feature only works with systemd 235 and above |

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `systemd_exporter_enable_restart_count` | false | Enables service restart count metrics. This feature only works with systemd 235 and above |
 | `systemd_exporter_enable_ip_accounting` | false | Enables service ip accounting metrics. This feature only works with systemd 235 and above |
 | `systemd_exporter_enable_file_descriptor_size` | false | Enables file descriptor size metrics. This feature will cause exporter to run as root as it needs access to /proc/X/fd |
-| `systemd_exporter_unit_allowlist` | "" | Include some systemd units. Expects a regex. More in https://github.com/povilasv/systemd_exporter#configuration |
-| `systemd_exporter_unit_denylist` | "" | Exclude some systemd units. Expects a regex. More in https://github.com/povilasv/systemd_exporter#configuration |
+| `systemd_exporter_unit_includelist` | "" | Include some systemd units. Expects a regex. More in https://github.com/povilasv/systemd_exporter#configuration |
+| `systemd_exporter_unit_excludelist` | "" | Exclude some systemd units. Expects a regex. More in https://github.com/povilasv/systemd_exporter#configuration |
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `systemd_exporter_enable_file_descriptor_size` | false | Enables file descriptor size metrics. This feature will cause exporter to run as root as it needs access to /proc/X/fd |
 | `systemd_exporter_unit_includelist` | "" | Include some systemd units. Expects a regex. More in https://github.com/povilasv/systemd_exporter#configuration |
 | `systemd_exporter_unit_excludelist` | "" | Exclude some systemd units. Expects a regex. More in https://github.com/povilasv/systemd_exporter#configuration |
+| `systemd_exporter_tls_server_config` | "" | See [exporter-toolkit's https README](https://github.com/prometheus/exporter-toolkit/blob/v0.1.0/https/README.md) |
+| `systemd_exporter_http_server_config` | "" | See [exporter-toolkit's https README](https://github.com/prometheus/exporter-toolkit/blob/v0.1.0/https/README.md) |
+| `systemd_exporter_basic_auth_users` | "" | See [exporter-toolkit's https README](https://github.com/prometheus/exporter-toolkit/blob/v0.1.0/https/README.md) |
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-Deploy prometheus [systemd exporter](https://github.com/povilasv/systemd_exporter) using ansible.
+Deploy prometheus [systemd exporter](https://github.com/prometheus-community/systemd_exporter) using ansible.
 
 ## Requirements
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,8 @@ systemd_exporter_enable_restart_count: false
 systemd_exporter_enable_ip_accounting: false
 systemd_exporter_enable_file_descriptor_size: false
 
-systemd_exporter_unit_whitelist: ""
-systemd_exporter_unit_blacklist: ""
+systemd_exporter_unit_includelist: ""
+systemd_exporter_unit_excludelist: ""
 
 # Following variables are meant for advanced users only. Changing those is not supported.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-systemd_exporter_version: 0.4.0
+systemd_exporter_version: 0.5.0
 systemd_exporter_binary_local_dir: ""
 systemd_exporter_web_listen_address: "0.0.0.0:9558"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,10 @@ systemd_exporter_enable_file_descriptor_size: false
 systemd_exporter_unit_includelist: ""
 systemd_exporter_unit_excludelist: ""
 
+systemd_exporter_tls_server_config: ""
+systemd_exporter_http_server_config: ""
+systemd_exporter_basic_auth_users: ""
+
 # Following variables are meant for advanced users only. Changing those is not supported.
 
 _systemd_exporter_binary_install_dir: "/usr/local/bin"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,6 +8,28 @@
     mode: 0644
   notify: restart systemd_exporter
 
+- block:
+    - name: Create systemd_exporter config directory
+      file:
+        path: "/etc/systemd_exporter"
+        state: directory
+        owner: root
+        group: root
+        mode: u+rwX,g+rwX,o=rX
+
+    - name: Copy the systemd_exporter config file
+      template:
+        src: config.yaml.j2
+        dest: /etc/systemd_exporter/config.yaml
+        owner: root
+        group: "{{_systemd_exporter_system_group}}"
+        mode: 0640
+      notify: restart systemd_exporter
+  when:
+    ( systemd_exporter_tls_server_config | length > 0 ) or
+    ( systemd_exporter_http_server_config | length > 0 ) or
+    ( systemd_exporter_basic_auth_users | length > 0 )
+
 - name: Allow systemd_exporter port in SELinux on RedHat OS family
   seport:
     ports: "{{ systemd_exporter_web_listen_address.split(':')[-1] }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,7 +21,7 @@
     - name: Download systemd_exporter binary to local folder
       become: false
       get_url:
-        url: "https://github.com/povilasv/systemd_exporter/releases/download/v{{ systemd_exporter_version }}/systemd_exporter-{{ systemd_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        url: "https://github.com/prometheus-community/systemd_exporter/releases/download/v{{ systemd_exporter_version }}/systemd_exporter-{{ systemd_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         dest: "/tmp/systemd_exporter-{{ systemd_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ systemd_exporter_checksum }}"
         mode: '0644'

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -56,7 +56,7 @@
 - block:
     - name: Get latest release
       uri:
-        url: "https://api.github.com/repos/povilasv/systemd_exporter/releases/latest"
+        url: "https://api.github.com/repos/prometheus-community/systemd_exporter/releases/latest"
         method: GET
         return_content: true
         status_code: 200
@@ -80,7 +80,7 @@
 - block:
     - name: Get checksum list from github
       set_fact:
-        _checksums: "{{ lookup('url', 'https://github.com/povilasv/systemd_exporter/releases/download/v' + systemd_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
+        _checksums: "{{ lookup('url', 'https://github.com/prometheus-community/systemd_exporter/releases/download/v' + systemd_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
       run_once: true
 
     - name: "Get checksum for {{ go_arch }} architecture"

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -24,7 +24,7 @@
 - name: Assert that systemd version is >= 235 when enabling ip accounting or measuring restart count
   assert:
     that:
-      - _systemd_exporter_systemd_version | int >= 232
+      - _systemd_exporter_systemd_version | int >= 235
   when: systemd_exporter_enable_ip_accounting or systemd_exporter_enable_restart_count
 
 - name: Set user and group to root to allow access to /proc/X/fd

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -1,0 +1,18 @@
+---
+{{ ansible_managed | comment }}
+{% if systemd_exporter_tls_server_config | length > 0 %}
+tls_server_config:
+{{ systemd_exporter_tls_server_config | to_nice_yaml | indent(2, true) }}
+{% endif %}
+
+{% if systemd_exporter_http_server_config | length > 0 %}
+http_server_config:
+{{ node_exporter_http_server_config | to_nice_yaml | indent(2, true) }}
+{% endif %}
+
+{% if systemd_exporter_basic_auth_users | length > 0 %}
+basic_auth_users:
+{% for k, v in systemd_exporter_basic_auth_users.items() %}
+  {{ k }}: {{ v | password_hash('bcrypt', ('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890' | shuffle(seed=inventory_hostname) | join)[:22], rounds=9) }}
+{% endfor %}
+{% endif %}

--- a/templates/systemd_exporter.service.j2
+++ b/templates/systemd_exporter.service.j2
@@ -24,6 +24,9 @@ ExecStart={{ _systemd_exporter_binary_install_dir }}/systemd_exporter \
 {% if systemd_exporter_unit_excludelist != "" %}
     --systemd.collector.unit-exclude="{{ systemd_exporter_unit_excludelist }}" \
 {% endif %}
+{% if systemd_exporter_tls_server_config | length > 0 or systemd_exporter_http_server_config | length > 0 or systemd_exporter_basic_auth_users | length > 0 %}
+    --web.config.file=/etc/systemd_exporter/config.yaml \
+{% endif %}
     --web.listen-address={{ systemd_exporter_web_listen_address }}
 
 SyslogIdentifier=systemd_exporter

--- a/templates/systemd_exporter.service.j2
+++ b/templates/systemd_exporter.service.j2
@@ -18,11 +18,11 @@ ExecStart={{ _systemd_exporter_binary_install_dir }}/systemd_exporter \
 {% if systemd_exporter_enable_ip_accounting %}
     --systemd.collector.enable-ip-accounting \
 {% endif %}
-{% if systemd_exporter_unit_whitelist != ""%}
-    --systemd.collector.unit-include={{ systemd_exporter_unit_whitelist }} \
+{% if systemd_exporter_unit_includelist != ""%}
+    --systemd.collector.unit-include="{{ systemd_exporter_unit_includelist }}" \
 {% endif %}
-{% if systemd_exporter_unit_blacklist != "" %}
-    --systemd.collector.unit-exclude={{ systemd_exporter_unit_blacklist }} \
+{% if systemd_exporter_unit_excludelist != "" %}
+    --systemd.collector.unit-exclude="{{ systemd_exporter_unit_excludelist }}" \
 {% endif %}
     --web.listen-address={{ systemd_exporter_web_listen_address }}
 

--- a/templates/systemd_exporter.service.j2
+++ b/templates/systemd_exporter.service.j2
@@ -10,19 +10,19 @@ User={{ _systemd_exporter_system_user }}
 Group={{ _systemd_exporter_system_group }}
 ExecStart={{ _systemd_exporter_binary_install_dir }}/systemd_exporter \
 {% if systemd_exporter_enable_restart_count %}
-    --collector.enable-restart-count \
+    --systemd.collector.enable-restart-count \
 {% endif %}
 {% if systemd_exporter_enable_file_descriptor_size %}
-    --collector.enable-file-descriptor-size \
+    --systemd.collector.enable-file-descriptor-size \
 {% endif %}
 {% if systemd_exporter_enable_ip_accounting %}
-    --collector.enable-ip-accounting \
+    --systemd.collector.enable-ip-accounting \
 {% endif %}
 {% if systemd_exporter_unit_whitelist != ""%}
-    --collector.unit-whitelist={{ systemd_exporter_unit_whitelist }} \
+    --systemd.collector.unit-include={{ systemd_exporter_unit_whitelist }} \
 {% endif %}
 {% if systemd_exporter_unit_blacklist != "" %}
-    --collector.unit-blacklist={{ systemd_exporter_unit_blacklist }} \
+    --systemd.collector.unit-exclude={{ systemd_exporter_unit_blacklist }} \
 {% endif %}
     --web.listen-address={{ systemd_exporter_web_listen_address }}
 


### PR DESCRIPTION
Initially I had individual MR but since some depend on each other having individual MR was not possible anymore.
So here is a general overhaul of this role to update it to the current systemd-exporter version (0.5.0).

Changes:

* new upstream repo location: https://github.com/prometheus-community/systemd_exporter
* migrate to current CLI parameter 
* renamed vars (whitelist -> includelist, blacklist -> excludelist)
* add support for `--web.config.file` (basic auth, TLS, HTTP/2)
* fix "Assert that systemd version is >= 235"