### PR TITLE
7 update flag sytax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 __pycache__/
 .pytest_cache
 .tox
+
+**/*.swp
+.python-version

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `systemd_exporter_enable_restart_count` | false | Enables service restart count metrics. This feature only works with systemd 235 and above |
 | `systemd_exporter_enable_ip_accounting` | false | Enables service ip accounting metrics. This feature only works with systemd 235 and above |
 | `systemd_exporter_enable_file_descriptor_size` | false | Enables file descriptor size metrics. This feature will cause exporter to run as root as it needs access to /proc/X/fd |
-| `systemd_exporter_unit_allowlist` | "" | Include some systemd units. Expects a regex. More in https://github.com/povilasv/systemd_exporter#configuration |
-| `systemd_exporter_unit_denylist` | "" | Exclude some systemd units. Expects a regex. More in https://github.com/povilasv/systemd_exporter#configuration |
+| `systemd_exporter_unit_include` | "" | Include some systemd units. Expects a regex. More in https://github.com/povilasv/systemd_exporter#configuration |
+| `systemd_exporter_unit_exclude` | "" | Exclude some systemd units. Expects a regex. More in https://github.com/povilasv/systemd_exporter#configuration |
 
 ## Example
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,8 @@ systemd_exporter_enable_restart_count: false
 systemd_exporter_enable_ip_accounting: false
 systemd_exporter_enable_file_descriptor_size: false
 
-systemd_exporter_unit_whitelist: ""
-systemd_exporter_unit_blacklist: ""
+systemd_exporter_unit_include: ""
+systemd_exporter_unit_exclude: ""
 
 # Following variables are meant for advanced users only. Changing those is not supported.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,7 @@ galaxy_info:
   author: Pawel Krupa
   description: Prometheus Systemd Exporter
   role_name: systemd_exporter
+  namespace: cloudalchemy
   license: MIT
   company: none
   min_ansible_version: 2.7

--- a/templates/systemd_exporter.service.j2
+++ b/templates/systemd_exporter.service.j2
@@ -10,19 +10,19 @@ User={{ _systemd_exporter_system_user }}
 Group={{ _systemd_exporter_system_group }}
 ExecStart={{ _systemd_exporter_binary_install_dir }}/systemd_exporter \
 {% if systemd_exporter_enable_restart_count %}
-    --collector.enable-restart-count \
+    --systemd.collector.enable-restart-count \
 {% endif %}
 {% if systemd_exporter_enable_file_descriptor_size %}
-    --collector.enable-file-descriptor-size \
+    --systemd.collector.enable-file-descriptor-size \
 {% endif %}
 {% if systemd_exporter_enable_ip_accounting %}
-    --collector.enable-ip-accounting \
+    --systemd.collector.enable-ip-accounting \
 {% endif %}
-{% if systemd_exporter_unit_whitelist != ""%}
-    --collector.unit-whitelist={{ systemd_exporter_unit_whitelist }} \
+{% if systemd_exporter_unit_include != ""%}
+    --systemd.collector.unit-include={{ systemd_exporter_unit_include }} \
 {% endif %}
-{% if systemd_exporter_unit_blacklist != "" %}
-    --collector.unit-blacklist={{ systemd_exporter_unit_blacklist }} \
+{% if systemd_exporter_unit_exclude != "" %}
+    --systemd.collector.unit-exclude={{ systemd_exporter_unit_exclude }} \
 {% endif %}
     --web.listen-address={{ systemd_exporter_web_listen_address }}
 


### PR DESCRIPTION
All tests passed except for `buster` and `fedora`, with the temporary directory creation errors, which is a problem with the way the containers are being used, I guess?

```
TASK [Gathering Facts] ********************************************************* 
fatal: [buster]: UNREACHABLE! => {"changed": false, "msg": "Failed to create temporary directory. In some cases, you may have been able to authenticate and did not have perm
issions on the target directory. Consider changing the remote tmp path in ansible.cfg to a path rooted in \"/tmp\", for more error information use -vvv. Failed command was: 
( umask 77 && mkdir -p \"` echo ~/.ansible/tmp `\"&& mkdir \"` echo ~/.ansible/tmp/ansible-tmp-1672261910.1531582-497150-73148195373829 `\" && echo ansible-tmp-1672261910.15
31582-497150-73148195373829=\"` echo ~/.ansible/tmp/ansible-tmp-1672261910.1531582-497150-73148195373829 `\" ), exited with result 1", "unreachable": true}                  
fatal: [fedora]: UNREACHABLE! => {"changed": false, "msg": "Failed to create temporary directory. In some cases, you may have been able to authenticate and did not have perm
issions on the target directory. Consider changing the remote tmp path in ansible.cfg to a path rooted in \"/tmp\", for more error information use -vvv. Failed command was: 
( umask 77 && mkdir -p \"` echo ~/.ansible/tmp `\"&& mkdir \"` echo ~/.ansible/tmp/ansible-tmp-1672261910.1936326-497153-209154217672942 `\" && echo ansible-tmp-1672261910.1
936326-497153-209154217672942=\"` echo ~/.ansible/tmp/ansible-tmp-1672261910.1936326-497153-209154217672942 `\" ), exited with result 1", "unreachable": true}               
ok: [centos8]                                                                                                                                                                
ok: [xenial]                                                                                                                                                                 
ok: [bionic]                      
ok: [stretch]                                                                         
ok: [centos7]  
                                                                                      
NO MORE HOSTS LEFT *************************************************************                                                                                             
                                                                                                                                                                             
PLAY RECAP *********************************************************************                                                                                             
bionic                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0                                                           
buster                     : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0                                                           
centos7                    : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
centos8                    : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
fedora                     : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0
stretch                    : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
xenial                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
                                           
WARNING  Retrying execution failure 2 of: ansible-playbook --inventory /home/bryant/.cache/molecule/ansible-systemd-exporter/default/inventory --skip-tags molecule-notest,no
test /home/bryant/src/ansible-systemd-exporter/molecule/default/playbook.yml
CRITICAL Ansible return code was 2, command was: ['ansible-playbook', '--inventory', '/home/bryant/.cache/molecule/ansible-systemd-exporter/default/inventory', '--skip-tags'
, 'molecule-notest,notest', '/home/bryant/src/ansible-systemd-exporter/molecule/default/playbook.yml']
WARNING  An error occurred during the test sequence action: 'converge'. Cleaning up.
INFO     Running default > cleanup   
WARNING  Skipping, cleanup playbook not configured.
INFO     Running default > destroy                                                    
```